### PR TITLE
Fix unauthenticated access to book write routes

### DIFF
--- a/app/routes.php
+++ b/app/routes.php
@@ -64,11 +64,14 @@ Route::group(array('before' => 'guest'), function() {
 	
 });
 
-// Main books Controlller left public so that it could be used without logging in too
-Route::resource('/books', 'BooksController');
+// Public read-only book routes for search/browse without logging in
+Route::resource('/books', 'BooksController', array('only' => array('index', 'show')));
 
-// Authenticated group 
+// Authenticated group
 Route::group(array('before' => 'auth'), function() {
+
+	// Protected book modification routes (require login)
+	Route::resource('/books', 'BooksController', array('only' => array('create', 'store', 'edit', 'update', 'destroy')));
 
 	// Home Page of Control Panel
 	Route::get('/',array(


### PR DESCRIPTION
## Summary

- The `Route::resource('/books', 'BooksController')` was placed outside the `auth` filter group, exposing `store`, `update`, and `destroy` endpoints to unauthenticated users — anyone could add, modify, or delete books without logging in.
- Split the resource route into **public read-only** routes (`index`, `show`) for book search/browse and **protected write** routes (`create`, `store`, `edit`, `update`, `destroy`) inside the `auth` group.

## What changed

**`app/routes.php`** — one resource route replaced with two scoped ones:

```php
// Before (all 7 RESTful routes publicly accessible)
Route::resource('/books', 'BooksController');

// After (read = public, write = auth-protected)
Route::resource('/books', 'BooksController', array('only' => array('index', 'show')));

Route::group(array('before' => 'auth'), function() {
    Route::resource('/books', 'BooksController', array('only' => array('create', 'store', 'edit', 'update', 'destroy')));
    // ...
});
```

## Test plan

- [ ] Verify `GET /books` (index) and `GET /books/{id}` (show) still work without login
- [ ] Verify `POST /books` (store) redirects to login when unauthenticated
- [ ] Verify `POST /books` (store) works correctly when logged in
- [ ] Verify book search page continues to function for guests